### PR TITLE
Updates for TIG informative content loading

### DIFF
--- a/db_models/ig_document.py
+++ b/db_models/ig_document.py
@@ -14,6 +14,7 @@ class IGDocument(BaseDBModel):
         self.parent_document_title = params.get("parentDocumentTitle")
         self.section = params.get("section")
         self.structures = params.get("structures")
+        self.use_case = params.get("useCase")
         self.children = []
         self.children_titles = []
     
@@ -86,5 +87,6 @@ class IGDocument(BaseDBModel):
             data["section"] = self.section
         if self.structures:
             data["structures"] = self.structures
-
+        if self.use_case:
+            data["useCase"] = self.use_case
         return data

--- a/utilities/document_tags.py
+++ b/utilities/document_tags.py
@@ -1,0 +1,5 @@
+USE_CASE="use_case"
+STRUCTURE="structure"
+STANDARD="standard"
+DOMAIN="domain"
+SECTION="section"


### PR DESCRIPTION
Steps to test:

Verify that IG documents for TIG are in the database using the query:

* `SELECT * FROM c WHERE c.version="tig-1-0"` on the ImplementationGuideDocuments table

