### PR TITLE
Several different TIG IC fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,13 @@ To load informative content into the database, for example, for TIG v 1-0:
 
 - Set the env variables (or use the defined command line arguments):
 
-   `CONFLUENCE_USERNAME`
-   `CONFLUENCE_PASSWORD`
-   `COSMOSDB_ENDPOINT`
-   `COSMOSDB_KEY`
-   `COSMOSDB_DATABASE_NAME`
+   - `CONFLUENCE_USERNAME`
+   - `CONFLUENCE_PASSWORD`
+   - `COSMOSDB_ENDPOINT`
+   - `COSMOSDB_KEY`
+   - `COSMOSDB_DATABASE_NAME`
+   - `AZURE_CONNECTION_STRING` - blob storage connection string
+   - `ENVIRONMENT` - `cdisclibrary` blob storage environment (`dev`, `qa`, `stage`, or <empty> for prod)
 
 - run the command:
 

--- a/db_models/ig_document.py
+++ b/db_models/ig_document.py
@@ -41,6 +41,7 @@ class IGDocument(BaseDBModel):
         )), None)
 
         if document:
+            document.title = record_params.get("title")
             document.html = record_params.get("html")
             document.text = record_params.get("text")
             document.parent_document = record_params.get("parent")

--- a/load_ig.py
+++ b/load_ig.py
@@ -19,6 +19,7 @@ def parse_arguments():
     parser.add_argument("-l", "--log_level")
     parser.add_argument("-v", "--version")
     parser.add_argument("-o", "--output", help="Name of the file to write data to. Defaults to assumptions.json", default="data.json")
+    parser.add_argument("-r", "--report_file", help="File containing document generation report", default="report.txt")
     args = parser.parse_args()
     return args
 
@@ -26,6 +27,9 @@ def create_logger(args):
     logger = logging.getLogger("load-ig-pipeline")
     logFormatter = logging.Formatter("%(asctime)s [%(levelname)-5.5s]  %(message)s")
     logger.setLevel(args.log_level or logging.DEBUG)
+    file_handler = logging.FileHandler(args.report_file, "w")
+    file_handler.setFormatter(logFormatter)
+    logger.addHandler(file_handler)
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(logFormatter)
     logger.addHandler(console_handler)

--- a/utilities/wiki_client.py
+++ b/utilities/wiki_client.py
@@ -39,7 +39,12 @@ class WikiClient:
         if raw_data.status_code == 200:
             if not raw_data.encoding:
                 raw_data.encoding = 'UTF-8'
-            return json.loads(raw_data.text)
+            json_data = json.loads(raw_data.text)
+            next = json_data["_links"].get("next")
+            if next:
+                base = json_data["_links"].get("base")
+                json_data["results"].extend(self.get_json(f"{base}{next}")["results"])
+            return json_data
         else:
             raise Exception(f"Get request to {url} returned unsuccessful response {raw_data.status_code}")
     
@@ -49,7 +54,7 @@ class WikiClient:
             raise Exception(f"Put request to {url} returned unsuccessful response {raw_data.status_code}")
         
     def get_wiki_table(self, document_id, table_name):
-        base_url = f"https://wiki.cdisc.org/ajax/confiforms/rest/filter.action?pageId={document_id}&f={table_name}&q="
+        base_url = f"{self.wiki_base_url}/ajax/confiforms/rest/filter.action?pageId={document_id}&f={table_name}&q="
         response = requests.get(base_url, auth=(self.username, self.password))
         if response.status_code != 200:
             raise Exception(f"Invalid url for wiki document {document_id} and table {table_name}")

--- a/utilities/wiki_document_parser.py
+++ b/utilities/wiki_document_parser.py
@@ -1,6 +1,5 @@
 from bs4 import BeautifulSoup
 from markdownify import markdownify
-from markdown import markdown
 from db_models.ig_document import IGDocument
 from uuid import uuid4
 from utilities.transformer import Transformer
@@ -11,6 +10,7 @@ from utilities import document_tags
 from typing import List
 import os
 from sys import maxsize
+from urllib.parse import unquote
 
 class Parser:
     
@@ -145,7 +145,7 @@ class Parser:
                 data = self.client.download_file(img_link)
                 image_path = img_link.split("?")[0]
                 image_file_name = f"{page_id}-{image_path.split('/')[-1]}"
-                self.image_blob_service.upload_file(data, image_file_name)
+                self.image_blob_service.upload_file(data, unquote(image_file_name))
                 base_url = f"https://cdisclibrary{os.environ.get('ENVIRONMENT', '').lower()}.blob.core.windows.net/images"
                 image_link_path = f"{base_url}/{image_file_name}"
                 attrs = {
@@ -156,8 +156,9 @@ class Parser:
                     attrs["height"] = img.attrs["height"]
                 img.attrs = attrs
                 self.logger.info(f"Successfully duplicated {img_link}")
-            except:
+            except Exception as e:
                 self.logger.error(f"Failed to duplicate {img_link}")
+                self.logger.error(e)
         return self.transformer.get_raw_text(str(parser))
         
 


### PR DESCRIPTION
This update includes several fixes to the TIG Informative Content extraction to address the issues found here:
https://dev.azure.com/cdisc-org/cdisc-library/_workitems/edit/5315
- Readme updated with guidance on adding `AZURE_CONNECTION_STRING` and `ENVIRONMENT` environment variables. Without these, the extracted images were not being saved to blob storage
- Bugfix Title updates added to the documents in case Document titles change names
- Bugfix wiki JSON queries were limited to 25 results. Updated to check the `next` attribute to get all result pages
- Bugfix image urls that contain spaces (`%20`) and other encoded characters were not able to be retrieved from blob storage. Resolved by url unquoting before saving to blob storage
- Added more log details for image extraction errors
- Added ability to save logs to report file
- Externalized hardcoded `https://wiki.cdisc.org` a little bit